### PR TITLE
Add initial scaffolding for netlify site build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+/site

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the documentation.
+.PHONY: docs
+docs:
+	# Ensure site dir exists
+	mkdir -p site
+
+	# Generate docs with mkdocs
+	mkdocs build

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,25 @@
+# Netlify build instructions
+[build]
+    command = "make docs"
+    publish = "site"
+    environment = { PYTHON_VERSION = "3.8" }
+
+# Standard Netlify redirects
+[[redirects]]
+    from = "https://main--kubernetes-sigs-multicluster.netlify.com/*"
+    to = "https://main.multicluster.sigs.k8s.io/:splat"
+    status = 301
+    force = true
+
+# HTTP-to-HTTPS rules
+[[redirects]]
+    from = "http://main.multicluster.sigs.k8s.io/*"
+    to = "https://main.multicluster.sigs.k8s.io/:splat"
+    status = 301
+    force = true
+
+[[redirects]]
+    from = "http://main--kubernetes-sigs-multicluster.netlify.com/*"
+    to = "http://main.multicluster.sigs.k8s.io/:splat"
+    status = 301
+    force = true


### PR DESCRIPTION
Add an initial `netlify.toml` based on https://github.com/kubernetes-sigs/gateway-api/blob/main/netlify.toml. I have just guessed at the values for the redirects so please let me know if the url should look different?

Also added some very basic initial scaffolding for building via `Makefile`, this will be flexible in the future if the build process gets more complex.

Part of umbrella issue: #4 