### PR TITLE
Refine workflow for site build and netlify deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+SHELL := /bin/bash
+
+# Install dependencies
+.PHONY: install
+install:
+	# Create python virtual environment
+	python3 -m venv venv/
+
+	# Active virtual environment
+	source ./venv/bin/activate
+
+	# Install python depdendencies
+	pip install -r requirements.txt
+
 
 # Build the documentation.
 .PHONY: docs
@@ -20,3 +34,13 @@ docs:
 
 	# Generate docs with mkdocs
 	mkdocs build
+
+
+# Cleanup local directory
+.PHONY: cleanup
+cleanup:
+	# Remove python virtual environment
+	rm -rf venv
+
+	# Remove site build
+	rm -rf site

--- a/README.md
+++ b/README.md
@@ -22,26 +22,17 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 ## Install and run
 
-Install Python and the requirements.
+Install Python and the requirements for this site using the included `Makefile`.
 
   ```
-    python3 -m venv venv/
-    source venv/bin/activate
-    pip install -r requirements.txt
+    make install
   ```
 
-Install the mkdocs plugins
-
-  ```
-  pip install mkdocs-awesome-pages-plugin
-  pip install mkdocs-macros-plugin
-  pip install mkdocs-redirects
-  ```
 Use the mkdocs CLI to serve a development version of the site.
 
   ```mkdocs serve```
 
-Navigate to localhost:8000 to see the site.
+Navigate to `localhost:8000` to see the site.
 
 ## Build and deploy
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,23 +3,3 @@
     command = "make docs"
     publish = "site"
     environment = { PYTHON_VERSION = "3.8" }
-
-# Standard Netlify redirects
-[[redirects]]
-    from = "https://main--kubernetes-sigs-multicluster.netlify.com/*"
-    to = "https://main.multicluster.sigs.k8s.io/:splat"
-    status = 301
-    force = true
-
-# HTTP-to-HTTPS rules
-[[redirects]]
-    from = "http://main.multicluster.sigs.k8s.io/*"
-    to = "https://main.multicluster.sigs.k8s.io/:splat"
-    status = 301
-    force = true
-
-[[redirects]]
-    from = "http://main--kubernetes-sigs-multicluster.netlify.com/*"
-    to = "http://main.multicluster.sigs.k8s.io/:splat"
-    status = 301
-    force = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 mkdocs-material
+mkdocs-awesome-pages-plugin
+mkdocs-macros-plugin
+mkdocs-redirects


### PR DESCRIPTION
This pull request:
  - Adds a new `make install` target so that future contributors only have a single command to run to setup a local development environment.
  - Adds a new `make cleanup` target to cleanup a local environment.
  - Updates `README.md` to refer to new simplified environment setup.
  - Updates `netlify.toml` to remove unnecessary redirects.

Relates to #4 