### PR TITLE
Fix about api version

### DIFF
--- a/site-src/api-types/cluster-set.md
+++ b/site-src/api-types/cluster-set.md
@@ -14,14 +14,14 @@ ClusterSet represents a specific pattern implemented by various organizations. A
 A cluster's ClusterSet membership is stored in the about.k8s.io/ClusterProperty `clusterset.k8s.io`.
 
 ## Cluster Metadata
-The ClusterSet is a Cluster-scoped ClusterProperty CRD (Customer Resource Definition), that stores a name and a value. 
+The ClusterSet is a Cluster-scoped ClusterProperty CRD (Customer Resource Definition), that stores a name and a value.
 
 This property can be used to:
 
 - uniquely identify clusters using a clusterID
 
-    ```yaml
-    apiVersion: about.k8s.io/v1
+    ```
+    apiVersion: about.k8s.io/v1beta1
     kind: ClusterProperty
     metadata:
       name: cluster.clusterset.k8s.io
@@ -31,29 +31,24 @@ This property can be used to:
 
 - uniquely identify the membership of a cluster in a ClusterSet for the lifetime of the membership.
 
-    ```yaml
-    apiVersion: about.k8s.io/v1
+    ```
+    apiVersion: about.k8s.io/v1beta1
     kind: ClusterProperty
     metadata:
       name: clusterset.k8s.io
     spec:
       value: mycoolclusterset
     ```
-    
+
 - Provide a reference point for multi-cluster tooling to build on within a cluster set, for example for DNS labels, for logging and tracing, etc.
 
 - Provide extra metadata space to store other cluster properties that might otherwise be implemented as ad-hoc annotations on semantically adjacent objects.
 
-    ```yaml
-    apiVersion: about.k8s.io/v1
+    ```
+    apiVersion: about.k8s.io/v1beta1
     kind: ClusterProperty
     metadata:
       name: fingerprint.mycoolimplementation.com
     spec:
       value: '{"major": "1","minor": "18","gitVersion": "v1.18.2","gitCommit": "52c56ce7a8272c798dbc29846288d7cd9fbae032","gitTreeState": "clean","buildDate": "2020-04-30T20:19:45Z","goVersion": "go1.13.9","compiler": "gc","platform": "linux/amd64"}'
     ```
-
-
-
-
-

--- a/site-src/concepts/about-api.md
+++ b/site-src/concepts/about-api.md
@@ -4,19 +4,19 @@ This document provides an overview of the About API.
 
 ![Alt](../images/about-api.png "About API")
 
-The About API allows metadata to be attached to individual clusters. 
+The About API allows metadata to be attached to individual clusters.
 The fundamental resource defined in the API is the ClusterProperty CRD.
 
 You can read more details about the API in [KEP-2149](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid).
 
 ## ClusterProperty CRD
 
-The ClusterProperty CRD is proposed to give a Kubernetes-native way of identifying clusters, however, it can be used to store any metadata about a cluster. 
+The ClusterProperty CRD is proposed to give a Kubernetes-native way of identifying clusters, however, it can be used to store any metadata about a cluster.
 
 ### Example
 
-```yaml
-apiVersion: about.k8s.io/v1
+```
+apiVersion: about.k8s.io/v1beta1
 kind: ClusterProperty
 metadata:
   name: cluster.clusterset.k8s.io
@@ -24,11 +24,10 @@ spec:
   value: cluster-1
 ```
 
-In the above example the ClusterProperty CRD is used to identify a cluster with the id of `cluster-1`. The key in this example `cluster.clusterset.k8s.io`, is one of the two proposed well-known properties. 
+In the above example the ClusterProperty CRD is used to identify a cluster with the id of `cluster-1`. The key in this example `cluster.clusterset.k8s.io`, is one of the two proposed well-known properties.
 
 ### Well-known properties
 There are two well-known properties proposed:
 
-- `cluster.clusterset.k8s.io` A unique ID or name of the cluster. The value is implementation-specific, but it should be unique within the scope of the cluster set.  
-- `clusterset.k8s.io` The cluster set that the cluster belongs to. A cluster which is part of a cluster set should have this property set. 
-
+- `cluster.clusterset.k8s.io` A unique ID or name of the cluster. The value is implementation-specific, but it should be unique within the scope of the cluster set.
+- `clusterset.k8s.io` The cluster set that the cluster belongs to. A cluster which is part of a cluster set should have this property set.

--- a/site-src/references/yaml.json
+++ b/site-src/references/yaml.json
@@ -2,8 +2,8 @@
 	"Work": {
 		"prefix": ["Work"],
 		"body": [
-			"apiVersion: multicluster.x-k8s.io/v1alpha1", 
-			"kind: Work", 
+			"apiVersion: multicluster.x-k8s.io/v1alpha1",
+			"kind: Work",
 			"metadata:",
 				"\tname: ${1:work-name}",
 				"\tnamespace: ${2:cluster-name}",
@@ -20,8 +20,8 @@
 	"ServiceImport": {
 		"prefix": ["ServiceImport"],
 		"body": [
-			"apiVersion: multicluster.x-k8s.io/v1alpha1", 
-			"kind: ServiceImport", 
+			"apiVersion: multicluster.x-k8s.io/v1alpha1",
+			"kind: ServiceImport",
 			"metadata:",
 				"\tname: ${1:service-name}",
 				"\tnamespace: ${2:demo}",
@@ -39,8 +39,8 @@
 	"ServiceExport": {
 		"prefix": ["ServiceExport"],
 		"body": [
-			"apiVersion: multicluster.x-k8s.io/v1alpha1", 
-			"kind: ServiceExport", 
+			"apiVersion: multicluster.x-k8s.io/v1alpha1",
+			"kind: ServiceExport",
 			"metadata:",
 				"\tname: ${1:service-name}",
 				"\tnamespace: ${2:demo}"
@@ -50,8 +50,8 @@
 	"EndPointSlice": {
 		"prefix": ["EndPointSlice"],
 		"body": [
-			"apiVersion: discovery.k8s.io/v1beta1", 
-			"kind: EndPointSlice", 
+			"apiVersion: discovery.k8s.io/v1beta1",
+			"kind: EndPointSlice",
 			"metadata:",
 				"\tname: ${1:imported-service-cluster-name}",
 				"\tnamespace: ${2:demo}",
@@ -82,8 +82,8 @@
 	"ClusterSet (About API)": {
 		"prefix": ["ClusterSet"],
 		"body": [
-			"apiVersion: about.k8s.io/v1", 
-			"kind: ClusterProperty", 
+			"apiVersion: about.k8s.io/v1beta1",
+			"kind: ClusterProperty",
 			"metadata:",
 				"\tname: clusterset.k8s.io",
 			"spec:",
@@ -94,7 +94,7 @@
 	"Cluster (About API)": {
 		"prefix": ["Cluster"],
 		"body": [
-			"apiVersion: about.k8s.io/v1",
+			"apiVersion: about.k8s.io/v1beta1",
 			"kind: ClusterProperty",
 			"metadata:",
 				"\tname: cluster.clusterset.k8s.io",


### PR DESCRIPTION
It seems ClusterProperty is in [v1alpha1](https://github.com/kubernetes-sigs/about-api/blob/0d7f66d277541261f3773d711b8b72aadc2f272a/clusterproperty/api/v1alpha1/clusterproperty_types.go#L17).

UPDATE: changed to v1beta1 as per https://github.com/kubernetes-sigs/about-api/pull/27