### PR TITLE
Fix Work API example implementation OCM-io doc URL

### DIFF
--- a/site-src/concepts/work-api.md
+++ b/site-src/concepts/work-api.md
@@ -52,6 +52,6 @@ There is a reference implementation available in the [GitHub repo](https://githu
 
 For more advanced Work API implementations:
 
-- Open Cluster Management [ManifestWork API](https://open-cluster-management.io/concepts/manifestwork/)
+- Open Cluster Management [ManifestWork API](https://open-cluster-management.io/docs/concepts/manifestwork/)
 - Karmada [Work API](https://github.com/karmada-io/api/tree/main/work/)
 - Azure [Work API](https://github.com/Azure/k8s-work-api)


### PR DESCRIPTION
Fix the URL to the [OCM](https://open-cluster-management.io/)'s Work API implementation.
