### PR TITLE
Configure the toc baselevel (2)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.snippets
   - toc:
+      baselevel: 2
       permalink: true
 nav:
   - Overview:


### PR DESCRIPTION
This ensures that the generated tables of contents on the right-hand side of each page includes all the headers, including first-level headers (counter-intuitively).