### PR TITLE
Switch to merged material extensions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,8 +25,8 @@ markdown_extensions:
   - admonition
   - meta
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.superfences


### PR DESCRIPTION
The emoji extensions are now part of material, use those instead of materialx.