### PR TITLE
Activate venvs for relevant commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,27 +13,26 @@
 # limitations under the License.
 SHELL := /bin/bash
 
+all: docs
+
 # Install dependencies
 .PHONY: install
 install:
 	# Create python virtual environment
 	python3 -m venv venv/
 
-	# Active virtual environment
-	source ./venv/bin/activate
-
-	# Install python depdendencies
-	pip install -r requirements.txt
+	# Activate virtual environment and install dependencies
+	source ./venv/bin/activate && pip install -r requirements.txt
 
 
-# Build the documentation.
+# Build the documentation
 .PHONY: docs
-docs:
+docs: install
 	# Ensure site dir exists
 	mkdir -p site
 
 	# Generate docs with mkdocs
-	mkdocs build
+	source ./venv/bin/activate && mkdocs build
 
 
 # Cleanup local directory


### PR DESCRIPTION
Since each command in a recipe runs in a separate shell, activating a venv has no effect on subsequent commands. This fixes that by running venv-relative commands in the same recipe "line".

While we're at it, make docs the default target, and ensure that the requirements are installed before attempting to run mkdocs.