### PR TITLE
Bi-weekly SIG MC meetings to become weekly per KCEU 2025 talk

### DIFF
--- a/site-src/contributing/index.md
+++ b/site-src/contributing/index.md
@@ -38,7 +38,7 @@ We also have a [Slack channel (sig-multicluster)][slack] on k8s.io for day-to-da
 
 ## Meetings
 
-Meetings discussing the evolution of the different APIs on SIG-Multicluster happen bi-weekly on Tuesdays at 9:30AM Pacific Time / 18:30 CET. Join kubernetes-sig-multicluster@googlegroups.com to get a calendar invite. 
+Meetings discussing the evolution of the different APIs on SIG-Multicluster happen weekly on Tuesdays at 9:30AM Pacific Time / 18:30 CET. Join kubernetes-sig-multicluster@googlegroups.com to get a calendar invite. 
 
 
 <iframe


### PR DESCRIPTION
[At KubeCon EU 2025](https://kccnceu2025.sched.com/event/bdc5825f28140f003a93d2a14ff479e2) it was announced the SIG would meet weekly ([slide 25](https://static.sched.com/hosted_files/kccnceu2025/12/SIG-Multicluster%20KCEU25-1.pdf)).

This updates the site to match the announcement.