### PR TITLE
Add a simple glossary page to top nav with basic definitions.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ nav:
   - Guides:
     - Index: guides/index.md
     - Implementation Guidelines: guides/guidelines.md
+  - Glossary:
+    - Index: references/glossary/index.md
   - Reference:
     - Namespace Sameness: concepts/namespace-sameness.md
     - ClusterSet: api-types/cluster-set.md

--- a/site-src/references/glossary/index.md
+++ b/site-src/references/glossary/index.md
@@ -1,0 +1,20 @@
+# Glossary
+
+About API: A cluster-local CRD to store arbitrary properties about a cluster. See [About API Overview](concepts/about-api.md). _Previously known as ClusterProperty API._
+
+Cluster Inventory: An old name for the project that became the ClusterProfile API. See _ClusterProfile API_.
+
+ClusterProfile API: A CRD intended to store information about member clusters in a clusterset. See [ClusterProfile API Overview](concepts/clusterprofile-api.md). _Previously known as Cluster Inventory._
+
+ClusterProperty API: An old name for the About API. See also _About API_.
+
+ClusterSet: A group of clusters governed by a signle authority, with a high degree of trust, and in which namespace sameness applies. See [ClusterSet reference](api-types/clusterset.md).
+
+Multicluster Services API: An CRD composed of the ServiceExport and ServiceImport Kinds, used to facilitate accessing Services across clusters. See [Multicluster Services API Overview](concepts/multicluster-services-api.md). _Also known as: MCS API, MCS._
+
+Namespace Sameness: A property of clusters in clustersets, in which Kubernetes objects of the same name in the same namespace are expected to behave similarly across the clusterset. See [Namespace Sameness reference](api-types/namespace-sameness.md).
+
+Work API: A CRD defining the Work Kind, intended to facilitate distributing workloads across multiple clusters. See [Work API Overview](concepts/work-api.md).
+
+
+

--- a/site-src/references/glossary/index.md
+++ b/site-src/references/glossary/index.md
@@ -1,13 +1,24 @@
 # Glossary
 
-About API: A cluster-local CRD to store arbitrary properties about a cluster. See [About API Overview](concepts/about-api.md).
+About API: A cluster-local CRD to store arbitrary properties about a cluster.
+See [About API Overview](concepts/about-api.md).
 
-ClusterProfile API: A CRD intended to store information about member clusters in a clusterset. See [ClusterProfile API Overview](concepts/clusterprofile-api.md).
+ClusterProfile API: A CRD intended to store information about member clusters in
+a clusterset. See [ClusterProfile API Overview](concepts/clusterprofile-api.md).
 
-ClusterSet: A group of clusters governed by a single authority, with a high degree of trust, and in which namespace sameness applies. See [ClusterSet reference](api-types/clusterset.md).
+ClusterSet: A group of clusters governed by a single authority, with a high
+degree of trust, and in which namespace sameness applies. See [ClusterSet
+reference](api-types/clusterset.md).
 
-Multicluster Services API: An CRD composed of the ServiceExport and ServiceImport Kinds, used to facilitate accessing Services across clusters. See [Multicluster Services API Overview](concepts/multicluster-services-api.md).
+Multicluster Services API: An CRD composed of the ServiceExport and
+ServiceImport Kinds, used to facilitate accessing Services across clusters. See
+[Multicluster Services API Overview](concepts/multicluster-services-api.md).
 
-Namespace Sameness: A property of clusters in clustersets, in which Kubernetes objects of the same name in the same namespace are expected to behave similarly across the clusterset. See [Namespace Sameness reference](api-types/namespace-sameness.md).
+Namespace Sameness: A property of clusters in clustersets, in which Kubernetes
+objects of the same name in the same namespace are expected to behave similarly
+across the clusterset. See [Namespace Sameness
+reference](api-types/namespace-sameness.md).
 
-Work API: A CRD defining the Work Kind, intended to facilitate distributing workloads across multiple clusters. See [Work API Overview](concepts/work-api.md).
+Work API: A CRD defining the Work Kind, intended to facilitate distributing
+workloads across multiple clusters. See [Work API
+Overview](concepts/work-api.md).

--- a/site-src/references/glossary/index.md
+++ b/site-src/references/glossary/index.md
@@ -1,20 +1,13 @@
 # Glossary
 
-About API: A cluster-local CRD to store arbitrary properties about a cluster. See [About API Overview](concepts/about-api.md). _Previously known as ClusterProperty API._
+About API: A cluster-local CRD to store arbitrary properties about a cluster. See [About API Overview](concepts/about-api.md).
 
-Cluster Inventory: An old name for the project that became the ClusterProfile API. See _ClusterProfile API_.
+ClusterProfile API: A CRD intended to store information about member clusters in a clusterset. See [ClusterProfile API Overview](concepts/clusterprofile-api.md).
 
-ClusterProfile API: A CRD intended to store information about member clusters in a clusterset. See [ClusterProfile API Overview](concepts/clusterprofile-api.md). _Previously known as Cluster Inventory._
+ClusterSet: A group of clusters governed by a single authority, with a high degree of trust, and in which namespace sameness applies. See [ClusterSet reference](api-types/clusterset.md).
 
-ClusterProperty API: An old name for the About API. See also _About API_.
-
-ClusterSet: A group of clusters governed by a signle authority, with a high degree of trust, and in which namespace sameness applies. See [ClusterSet reference](api-types/clusterset.md).
-
-Multicluster Services API: An CRD composed of the ServiceExport and ServiceImport Kinds, used to facilitate accessing Services across clusters. See [Multicluster Services API Overview](concepts/multicluster-services-api.md). _Also known as: MCS API, MCS._
+Multicluster Services API: An CRD composed of the ServiceExport and ServiceImport Kinds, used to facilitate accessing Services across clusters. See [Multicluster Services API Overview](concepts/multicluster-services-api.md).
 
 Namespace Sameness: A property of clusters in clustersets, in which Kubernetes objects of the same name in the same namespace are expected to behave similarly across the clusterset. See [Namespace Sameness reference](api-types/namespace-sameness.md).
 
 Work API: A CRD defining the Work Kind, intended to facilitate distributing workloads across multiple clusters. See [Work API Overview](concepts/work-api.md).
-
-
-


### PR DESCRIPTION
This PR is to add the new page to nav and one-liner definitions of things already defined in the website, not add any new definitions yet.

I think this provides another useful, short-form variation of this information for the website audience, as well as is intended to facilitate the goals in capturing variations in terminology discussed in comment https://github.com/kubernetes/community/pull/8210#issuecomment-3012304521.

Quick link to netlify preview page in question: https://deploy-preview-41--kubernetes-sig-multicluster.netlify.app/references/glossary/