### PR TITLE
Conformance report directory and auto-generate comparison matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 /site
+site-src/implementations/*/conformance-matrix.md

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,14 @@ install:
 	source ./venv/bin/activate && pip install -r requirements.txt
 
 
+# Generate conformance comparison pages
+.PHONY: generate-conformance
+generate-conformance:
+	source ./venv/bin/activate && python hack/generate-conformance-matrix.py
+
 # Build the documentation
 .PHONY: docs
-docs: install
+docs: install generate-conformance
 	# Ensure site dir exists
 	mkdir -p site
 

--- a/hack/generate-conformance-matrix.py
+++ b/hack/generate-conformance-matrix.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate per-version conformance comparison pages from submitted YAML report files.
+
+Scans all project directories under the implementations root for a reports/
+subdirectory containing reports as YAML files. Generates comparison Markdown pages
+under each project's directory.
+
+Expected layout:
+site-src/
+    implementations/
+        mcs-implementations/
+            reports/
+                v0.4.1/submariner/v0.23.0.yaml    (submitted)
+                v0.4.1/gke/2026-01-01.yaml        (submitted)
+                v0.4.1/gke/2026-07-01.yaml        (submitted)
+            conformance-matrix.md                 (generated)
+"""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+REPO_URL = "https://github.com/kubernetes-sigs/sig-multicluster-site"
+IMPLEMENTATIONS_DIR = "site-src/implementations"
+
+
+@dataclass
+class ReportData:
+    organization: str
+    project: str
+    version: str
+    url: str
+    passed: int
+    total: int
+    required_passed: int
+    required_total: int
+    report_path: str
+
+
+def compute_required_counts(groups: list[dict[str, Any]]) -> tuple[int, int]:
+    """Compute required test counts from the groups field in a report.
+
+    Iterates through test groups and counts passed/total for
+    required tests (group name == "Required").
+    Returns: (required_passed, required_total)
+    """
+    required_passed = 0
+    required_total = 0
+
+    for group in groups:
+        if group.get("name") != "Required":
+            continue
+        for test in group.get("tests", []):
+            required_total += 1
+            if test.get("passed", False):
+                required_passed += 1
+
+    return required_passed, required_total
+
+
+def parse_report(report_file: pathlib.Path) -> ReportData:
+    """Parse a single report.yaml file and return a ReportData instance."""
+    with open(report_file) as f:
+        data: dict[str, Any] = yaml.safe_load(f)
+
+    impl: dict[str, Any] = data.get("implementation", {})
+    required_passed, required_total = compute_required_counts(data.get("groups", []))
+
+    return ReportData(
+        organization=impl.get("organization", ""),
+        project=impl.get("project", ""),
+        version=impl.get("version", ""),
+        url=impl.get("url", ""),
+        passed=data.get("passed", "Not found"),
+        total=data.get("total", "Not found"),
+        required_passed=required_passed,
+        required_total=required_total,
+        report_path=str(report_file),
+    )
+
+
+def generate_version_section(version: str, reports: list[ReportData]) -> str:
+    """Generate Markdown table for a single API version."""
+    lines = [
+        f"## {version}",
+        "| Organization | Project | Version | Required Tests | Total Tests | Report |",
+        "|---|---|---|---|---|---|",
+    ]
+
+    for r in reports:
+        project = r.project
+        if r.url:
+            project = f"[{r.project}]({r.url})"
+
+        report_name = pathlib.Path(r.report_path).name
+        report_link = f"[{report_name}]({REPO_URL}/blob/main/{r.report_path})"
+
+        # for green ticks to appear if all required tests passed/ if all tests passed
+        req_check = " :white_check_mark:" if r.required_passed == r.required_total else ""
+        total_check = " :white_check_mark:" if r.passed == r.total else ""
+
+        lines.append(
+            f"| {r.organization} | {project} | {r.version} "
+            f"| {r.required_passed}/{r.required_total}{req_check} "
+            f"| {r.passed}/{r.total}{total_check} | {report_link} |"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    implementations_dir = pathlib.Path(IMPLEMENTATIONS_DIR)
+
+    for project_dir in sorted(d for d in implementations_dir.iterdir() if d.is_dir()):
+        reports_dir = pathlib.Path.joinpath(project_dir, "reports")
+
+        reports_by_version: dict[str, list[ReportData]] = {}
+        for report_file in sorted(reports_dir.glob("*/*/*.yaml")):
+            api_version = report_file.parent.parent.name
+            reports_by_version.setdefault(api_version, []).append(parse_report(report_file))
+
+        output_file = pathlib.Path.joinpath(project_dir, "conformance-matrix.md")
+
+        # Sort implementations alphabetically by organization then project
+        for api_version in reports_by_version:
+            reports_by_version[api_version].sort(
+                key=lambda r: (r.organization.lower(), r.project.lower())
+            )
+
+        versions = sorted(reports_by_version.keys(), reverse=True) # versions in descending order
+        sections = [generate_version_section(v, reports_by_version[v]) for v in versions]
+        output_file.write_text("\n".join(sections))
+        print(f"Generated {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ plugins:
   - awesome-pages
   - redirects:
       redirect_maps:
-        'guides/getting-started.md': 'implementations/mcs-implementations.md'
+        'guides/getting-started.md': 'implementations/mcs-implementations/index.md'
         'contributing/community.md': 'contributing/index.md'
 markdown_extensions:
   - admonition
@@ -43,7 +43,9 @@ nav:
   - Implementations:
     - Index: implementations/index.md
     - Implementation Guidelines: implementations/guidelines.md
-    - Multicluster Services Implementations: implementations/mcs-implementations.md
+    - Multicluster Services Implementations:
+      - Index: implementations/mcs-implementations/index.md
+      - Comparisons: implementations/mcs-implementations/comparisons.md
     - Cluster Inventory API Implementations: implementations/cluster-inventory-api-implementations.md
   - Glossary:
     - Index: references/glossary/index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs-material
 mkdocs-awesome-pages-plugin
 mkdocs-macros-plugin
 mkdocs-redirects
+pyyaml

--- a/site-src/concepts/multicluster-services-api.md
+++ b/site-src/concepts/multicluster-services-api.md
@@ -4,7 +4,7 @@ This document provides an overview of Multicluster Services API.
 
 This is an extension of the Services concept across multiple clusters. Services are the basic way that workloads communicate with each other in Kubernetes, and the Multicluster Services builds upon the [Namespace Sameness](./namespace-sameness.md) concept to extend Services across multiclusters. In short, Services can remain available across clusters simply by using the same names. The Control Plane can be centralized or decentralized, but consumers only rely on local data.
 
-This document solely focuses on the API and the common behaviour, leaving room for various [implementations](../implementations/mcs-implementations.md). There is no reference implementation available.
+This document solely focuses on the API and the common behaviour, leaving room for various [implementations](../implementations/mcs-implementations/index.md). There is no reference implementation available.
 
 The intent of the Multicluster Services API is that ClusterIP and headless services just work as expected across clusters.
 

--- a/site-src/implementations/index.md
+++ b/site-src/implementations/index.md
@@ -1,5 +1,5 @@
 # Implementations
 
 * [Implementation Guidelines](./guidelines.md)
-* [MCS Implementations](./mcs-implementations.md)
+* [MCS Implementations](./mcs-implementations/index.md)
 * [Cluster Inventory API Implementations](./cluster-inventory-api-implementations.md)

--- a/site-src/implementations/mcs-implementations/comparisons.md
+++ b/site-src/implementations/mcs-implementations/comparisons.md
@@ -1,0 +1,4 @@
+# Conformance Comparisons
+The latest MCS API version is <a href="https://github.com/kubernetes-sigs/mcs-api/releases/latest"><img src="https://img.shields.io/github/v/release/kubernetes-sigs/mcs-api?label=&color=green" style="vertical-align: middle;" alt="MCS API Latest Release"></a>. Below are the conformance test results submitted by known implementations, grouped by conformance suite version.
+
+--8<-- "site-src/implementations/mcs-implementations/conformance-matrix.md"

--- a/site-src/implementations/mcs-implementations/index.md
+++ b/site-src/implementations/mcs-implementations/index.md
@@ -4,6 +4,10 @@ This document tracks downstream implementations and integrations of Multicluster
 
 Implementors and integrators of MCS API are encouraged to update this document with status information about their implementations, the versions they cover, and documentation to help users get started.
 
+## Conformance Comparisons
+
+See the [Comparisons](comparisons.md) page for conformance test results submitted by implementations. To submit a report, see the [submission instructions](reports/README.md).
+
 ## Implementation Status
 
 - [Google Cloud MCS][gke-mcs]: General Availability

--- a/site-src/implementations/mcs-implementations/reports/README.md
+++ b/site-src/implementations/mcs-implementations/reports/README.md
@@ -1,0 +1,54 @@
+# Submitting a Conformance Report
+
+This directory contains conformance reports submitted by MCS API implementers.
+
+## Directory Structure
+
+```
+reports/
+  <conformance-version>/
+    <impl-name>/
+      <impl-version>.yaml
+```
+
+For example:
+
+```
+reports/
+  v0.5.0/
+    submariner/
+      v0.23.0.yaml
+    gke/
+      2026-01-01.yaml
+      2026-07-01.yaml
+```
+
+## How to Submit
+
+1. **Run the conformance suite** against your implementation. Check out a
+   tagged release of the [mcs-api repository](https://github.com/kubernetes-sigs/mcs-api)
+   (e.g., `git checkout v0.5.0`) and run the suite, providing the following
+   flags to identify your implementation:
+   - `--organization` — your organization name (e.g., "Google Cloud")
+   - `--project` — your project name (e.g., "GKE Multi Cluster Service")
+   - `--version` — your implementation version (e.g., "1.2.0")
+   - `--url` — link to your project's documentation
+
+2. **Copy the generated `report.yaml`** into the appropriate directory:
+   `reports/<conformance-version>/<impl-name>/<impl-version>.yaml`
+
+   - `<conformance-version>` is the released version of the mcs-api conformance suite you ran (e.g., `v0.5.0`)
+   - `<impl-name>` is a lowercase identifier for your implementation (e.g., `submariner`, `gke`, `cilium`)
+   - Optionally rename the file to your implementation version (e.g., `v0.23.0.yaml`, `2026-01-01.yaml`) — `report.yaml` is also fine
+
+3. **Open a pull request** against the
+   [sig-multicluster-site](https://github.com/kubernetes-sigs/sig-multicluster-site) repository.
+
+## Requirements
+
+The YAML report file must contain non-empty values for the following fields under `implementation`:
+
+- `organization`
+- `project`
+- `version`
+- `url`


### PR DESCRIPTION
Fixes: #52 

### Summary
1. Adds a standardized directory structure (`reports/<api-version>/<impl-slug>/report.yaml`) for MCS API implementers to submit conformance test results                                                            
2. Adds a Python script (`hack/generate-conformance-matrix.py`) that auto-generates per-version comparison pages from submitted reports during site build
3. Wires generation into `make docs` so comparison matrix pages are built with the new report

Implementers submit a `report.yaml` (output of the [mcs-api conformance suite](https://github.com/kubernetes-sigs/mcs-api/tree/master/conformance)) via PR. The site build generates Markdown comparison tables from those reports — no manual HTML/matrix work needed from contributors.

  ### Changes                                                                                                                                                                                                      
  - `hack/generate-conformance-matrix.py` — scans reports, generates comparison `.md` pages
  - `Makefile` — new `generate-conformance` target, added as dependency of `docs`                                                                                                
  - `mkdocs.yml` — nav entry for comparisons & updated the path from `mcs-implementations.md` to `mcs-implementations/index.md`
  - `site-src/implementations/mcs-implementations/` — migrated from flat file to directory with `index.md`, `reports/README.md` (submission instructions)
  - `.gitignore` — ignore `comparisons/` directory which stores the comparison matrix per mcs-api version
  - `requirements.txt` — added `pyyaml` to read yaml file -- report.yaml

### Test plan 
1. locally verified that when a sample report.yaml is placed under `reports/v0.4.1/test-proj` and the site is built using `make generate-conformance` and then `make serve` the comparison matrix table appears