### PR TITLE
mcs-api/reports: add Cilium v1.20.0-dev

### DIFF
--- a/site-src/implementations/mcs-implementations/reports/cilium.md
+++ b/site-src/implementations/mcs-implementations/reports/cilium.md
@@ -1,0 +1,14 @@
+# How to reproduce Cilium conformance reports
+
+Cilium generally submits conformance reports from CI runs, which are
+linked in the commit or PR description that adds a specific report.
+
+Alternatively, you can run the tests with the official MCS-API conformance
+suite version of your choice against any Cilium Cluster Mesh setup with
+EndpointSliceSync and MCS-API support enabled.
+
+For instructions on how to set up a Cilium Cluster Mesh environment, check out
+these links to the Cilium documentation:
+- https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/
+- https://docs.cilium.io/en/stable/network/clustermesh/mcsapi/
+- https://docs.cilium.io/en/stable/network/clustermesh/services/#endpointslicesync

--- a/site-src/implementations/mcs-implementations/reports/v0.5.0/cilium/1.20.0.yaml
+++ b/site-src/implementations/mcs-implementations/reports/v0.5.0/cilium/1.20.0.yaml
@@ -1,0 +1,267 @@
+groups:
+    - name: Required
+      tests:
+        - desc: A ServiceImport should only exist as long as there's at least one exporting cluster
+          ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#importing-services
+          labels: []
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A service exported on two clusters with conflicting headlessness should apply the conflict resolution policy and report a Conflict condition on the ServiceExport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#headlessness
+          labels: []
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Connectivity to a service that is not exported should be inaccessible
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#exporting-services
+          labels: []
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A ClusterIP service exported on two clusters should expose the union of the constituent service ports and raise a conflict
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A ClusterIP service exported on two clusters with conflicting ports should apply the conflict resolution policy and report a Conflict condition on each ServiceExport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: An IP should be allocated for a ClusterSetIP ServiceImport for each IP family
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Exporting a ClusterIP service should create a ServiceImport of type ClusterSetIP in the service's namespace in each cluster. Unexporting should delete the ServiceImport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#importing-services
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: The InternalTrafficPolicy for a ClusterSetIP ServiceImport should match the exported service's InternalTrafficPolicy
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#internal-traffic-policy
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: The SessionAffinity for a ClusterSetIP ServiceImport should match the exported service's SessionAffinity
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#session-affinity
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: The TrafficDistribution for a ClusterSetIP ServiceImport should match the exported service's TrafficDistribution
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#traffic-distribution
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: The ports for a ClusterSetIP ServiceImport should match those of the exported service
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port
+          labels:
+            - ClusterIP
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Exporting an ExternalName service should set ServiceExport Valid condition to False
+          ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#service-types
+          labels:
+            - ExternalName
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Exporting a headless service should create a ServiceImport of type Headless in the service's namespace in each cluster. Unexporting should delete the ServiceImport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-types
+          labels:
+            - Headless
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: No clusterset IP should be allocated for a Headless ServiceImport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip
+          labels:
+            - Headless
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+    - name: Optional
+      tests:
+        - desc: Connectivity to a ClusterIP service existing in two clusters but exported from one should only access the exporting cluster
+          ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#exporting-services
+          labels:
+            - ClusterIP
+            - Connectivity
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Connectivity to an exported ClusterIP service should be accessible through DNS
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - ClusterIP
+            - Connectivity
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Connectivity to exported services with different port name on each cluster should route traffic to each port only to the cluster that exposes it
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port
+          labels:
+            - ClusterIP
+            - Connectivity
+            - StrictPortConflict
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Connectivity to exported services with same port name but different port numbers on each cluster should only route traffic to the cluster that exposes the port
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port
+          labels:
+            - ClusterIP
+            - Connectivity
+            - StrictPortConflict
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A DNS SRV query of the <service>.<ns>.svc.clusterset.local domain for a ClusterIP service should return valid SRV records
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - ClusterIP
+            - DNS
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A DNS lookup of the <service>.<ns>.svc.clusterset.local domain for a ClusterIP service should resolve to the clusterset IP
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - ClusterIP
+            - DNS
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: DNS lookups of the <service>.<ns>.svc.cluster.local domain for a ClusterIP service should only resolve local services
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - ClusterIP
+            - DNS
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A DNS query of the <hostname>.<clusterid>.<service>.<ns>.svc.clusterset.local domain for a headless StatefulSet service should return the requested pod's endpoint address
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - DNS
+            - EndpointSlice
+            - Headless
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A DNS SRV query of the <service>.<ns>.svc.clusterset.local domain for a headless service should return valid SRV records
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - DNS
+            - Headless
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: A DNS query of the <service>.<ns>.svc.clusterset.local domain for a headless service should return the ready endpoint addresses of all the backing pods
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns
+          labels:
+            - DNS
+            - Headless
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Exporting a service should create an MCS EndpointSlice in the service's namespace in each cluster with the required MCS labels. Unexporting should delete the EndpointSlice.
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#using-endpointslice-objects-to-track-endpoints
+          labels:
+            - EndpointSlice
+          passed: false
+          failed: false
+          skipped: true
+          conformant: true
+          message: ""
+        - desc: A service exported on two clusters with conflicting annotations and labels should apply the conflict resolution policy and report a Conflict condition on each ServiceExport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port
+          labels:
+            - ExportedLabels
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+        - desc: Only labels and annotations specified as exported in the ServiceExport should be propagated to the ServiceImport
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#labels-and-annotations
+          labels:
+            - ExportedLabels
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
+suitefailure: ""
+dnsdomain: clusterset.local
+passed: 26
+total: 27
+implementation:
+    organization: Cilium
+    project: Cilium
+    version: 1.20.0-dev
+    url: https://cilium.io/


### PR DESCRIPTION
Add 1.20.0-dev conformance report from Cilium. Note that this is a dev version but we will overwrite it with a version from a release once available (July 2026).

This was directly downloaded from our CI with this exact run: https://github.com/cilium/cilium/actions/runs/26102346479 (the exact artifact can be downloaded only for a few days). But it can be reproduced with a standard Cilium Cluster Mesh with EndpointSliceSync + MCS-API support.