### PR TITLE
Generate detailed MCS conformance report Markdown 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 /site
-site-src/implementations/*/conformance-matrix.md
+__pycache__/
+site-src/implementations/*/generated/

--- a/hack/generate-conformance-matrix.py
+++ b/hack/generate-conformance-matrix.py
@@ -13,20 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generate per-version conformance comparison pages from submitted YAML report files.
+"""Generate per-version MCS API conformance comparison page from submitted YAML reports.
 
-Scans all project directories under the implementations root for a reports/
-subdirectory containing reports as YAML files. Generates comparison Markdown pages
-under each project's directory.
+Scans the mcs-implementations reports/ subdirectory for reports as YAML files and
+generates a comparison Markdown page in the mcs-implementations directory.
 
 Expected layout:
 site-src/
     implementations/
         mcs-implementations/
             reports/
-                v0.4.1/submariner/v0.23.0.yaml    (submitted)
-                v0.4.1/gke/2026-01-01.yaml        (submitted)
-                v0.4.1/gke/2026-07-01.yaml        (submitted)
+                v0.5.0/submariner/v0.23.0.yaml    (submitted)
+                v0.5.0/gke/2026-01-01.yaml        (submitted)
+                v0.5.0/gke/2026-07-01.yaml        (submitted)
             conformance-matrix.md                 (generated)
 """
 
@@ -34,122 +33,134 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 
 import yaml
 
 REPO_URL = "https://github.com/kubernetes-sigs/sig-multicluster-site"
-IMPLEMENTATIONS_DIR = "site-src/implementations"
+MCS_IMPLEMENTATIONS_DIR = "site-src/implementations/mcs-implementations"
 
 
 @dataclass
-class ReportData:
-    organization: str
-    project: str
-    version: str
-    url: str
-    passed: int
-    total: int
-    required_passed: int
-    required_total: int
-    report_path: str
+class SubmittedReport:
+    """A single submitted conformance report by an implementer"""
+    report_yaml: dict[str, Any]
+    report_file: pathlib.Path
+
+    def row(self) -> str:
+        """Generates each table row in the comparisons page"""
+        report_link = f"[{self.report_file.name}]({REPO_URL}/blob/main/{self.report_file.as_posix()})"
+        cols: list[str] = []
+        required_passed, required_total = self.required_counts()
+        cols.append(self.organization())
+        cols.append(self.project_col())
+        cols.append(self.version())
+        cols.append(self.tests_col(required_passed, required_total)) # Required Tests
+        cols.append(self.tests_col(self.passed(), self.total())) # Total Tests
+        cols.append(report_link) # Report
+        return "| " + " | ".join(cols) + " |"
+
+    def tests_col(self, passed: int, total: int) -> str:
+        green_tick = " :white_check_mark:" if passed == total else ""
+        return f"{passed}/{total}{green_tick}"
+
+    def project_col(self) -> str:
+        if self.url():
+            return f"[{self.project()}]({self.url()})"
+        return self.project()
+
+    def required_counts(self) -> tuple[int, int]:
+        required_passed = 0
+        required_total = 0
+
+        for group in self.report_yaml["groups"]:
+            if group["name"] != "Required":
+                continue  # skip non-required groups
+
+            for test in group["tests"]:
+                required_total += 1
+                if test["passed"]:
+                    required_passed += 1
+
+        return required_passed, required_total
+
+    def project(self) -> str:
+        return self.report_yaml["implementation"].get("project", "")
+
+    def version(self) -> str:
+        return self.report_yaml["implementation"].get("version", "")
+
+    def url(self) -> str:
+        return self.report_yaml["implementation"].get("url", "")
+
+    def passed(self) -> int:
+        return self.report_yaml["passed"]
+
+    def total(self) -> int:
+        return self.report_yaml["total"]
+
+    def organization(self) -> str:
+        return self.report_yaml["implementation"].get("organization", "")
 
 
-def compute_required_counts(groups: list[dict[str, Any]]) -> tuple[int, int]:
-    """Compute required test counts from the groups field in a report.
+@dataclass
+class ConformanceMatrix:
+    """Collects submitted reports by MCS API version and renders the comparison matrix."""
+    reports_by_version: dict[str, list[SubmittedReport]] = field(default_factory=dict)
 
-    Iterates through test groups and counts passed/total for
-    required tests (group name == "Required").
-    Returns: (required_passed, required_total)
-    """
-    required_passed = 0
-    required_total = 0
+    @staticmethod
+    def header() -> list[str]:
+        return [
+            "| Organization | Project | Version | Required Tests | Total Tests | Report |",
+            "|---|---|---|---|---|---|",
+        ]
 
-    for group in groups:
-        if group.get("name") != "Required":
-            continue
-        for test in group.get("tests", []):
-            required_total += 1
-            if test.get("passed", False):
-                required_passed += 1
+    def matrix(self, mcs_api_ver: str, submitted_reports: list[SubmittedReport]) -> str:
+        """Generates comparisons tables for a single MCS version"""
+        lines: list[str] = [f"## {mcs_api_ver}"]
+        lines.extend(self.header())
+        for submitted_report in submitted_reports:
+            lines.append(submitted_report.row())
+        return "\n".join(lines)
 
-    return required_passed, required_total
+    def add_report(self, mcs_api_ver: str, submitted_report: SubmittedReport) -> None:
+        self.reports_by_version.setdefault(mcs_api_ver, []).append(submitted_report)
 
+    def generate_reports(self) -> str:
+        """Generates all the tables in mcs-implementations/comparisons/"""
+        self.sort()
+        tables: list[str] = []
+        # Iterate in descending order of MCS version
+        for mcs_api_ver in sorted(self.reports_by_version.keys(), reverse=True):
+            tables.append(self.matrix(mcs_api_ver, self.reports_by_version[mcs_api_ver]))
+        return "\n\n".join(tables)
 
-def parse_report(report_file: pathlib.Path) -> ReportData:
-    """Parse a single report.yaml file and return a ReportData instance."""
-    with open(report_file) as f:
-        data: dict[str, Any] = yaml.safe_load(f)
-
-    impl: dict[str, Any] = data.get("implementation", {})
-    required_passed, required_total = compute_required_counts(data.get("groups", []))
-
-    return ReportData(
-        organization=impl.get("organization", ""),
-        project=impl.get("project", ""),
-        version=impl.get("version", ""),
-        url=impl.get("url", ""),
-        passed=data.get("passed", "Not found"),
-        total=data.get("total", "Not found"),
-        required_passed=required_passed,
-        required_total=required_total,
-        report_path=str(report_file),
-    )
-
-
-def generate_version_section(version: str, reports: list[ReportData]) -> str:
-    """Generate Markdown table for a single API version."""
-    lines = [
-        f"## {version}",
-        "| Organization | Project | Version | Required Tests | Total Tests | Report |",
-        "|---|---|---|---|---|---|",
-    ]
-
-    for r in reports:
-        project = r.project
-        if r.url:
-            project = f"[{r.project}]({r.url})"
-
-        report_name = pathlib.Path(r.report_path).name
-        report_link = f"[{report_name}]({REPO_URL}/blob/main/{r.report_path})"
-
-        # for green ticks to appear if all required tests passed/ if all tests passed
-        req_check = " :white_check_mark:" if r.required_passed == r.required_total else ""
-        total_check = " :white_check_mark:" if r.passed == r.total else ""
-
-        lines.append(
-            f"| {r.organization} | {project} | {r.version} "
-            f"| {r.required_passed}/{r.required_total}{req_check} "
-            f"| {r.passed}/{r.total}{total_check} | {report_link} |"
-        )
-
-    lines.append("")
-    return "\n".join(lines)
+    def sort(self) -> None:
+        """Sort reports per MCS ver in ascending order of organization name then project name"""
+        for submitted_reports in self.reports_by_version.values():
+            submitted_reports.sort(key=lambda r: (r.organization().lower(), r.project().lower()))
 
 
 def main() -> None:
-    implementations_dir = pathlib.Path(IMPLEMENTATIONS_DIR)
+    project_dir = pathlib.Path(MCS_IMPLEMENTATIONS_DIR)
+    reports_dir = project_dir / "reports"
 
-    for project_dir in sorted(d for d in implementations_dir.iterdir() if d.is_dir()):
-        reports_dir = pathlib.Path.joinpath(project_dir, "reports")
+    matrix = ConformanceMatrix()
+    for report_file in sorted(reports_dir.glob("*/*/*.yaml")):
+        with open(report_file) as f:
+            report_yaml: dict[str, Any] = yaml.safe_load(f)
+        mcs_api_ver = report_file.parent.parent.name
+        submitted_report = SubmittedReport(
+            report_yaml=report_yaml,
+            report_file=report_file,
+        )
+        matrix.add_report(mcs_api_ver, submitted_report)
 
-        reports_by_version: dict[str, list[ReportData]] = {}
-        for report_file in sorted(reports_dir.glob("*/*/*.yaml")):
-            api_version = report_file.parent.parent.name
-            reports_by_version.setdefault(api_version, []).append(parse_report(report_file))
-
-        output_file = pathlib.Path.joinpath(project_dir, "conformance-matrix.md")
-
-        # Sort implementations alphabetically by organization then project
-        for api_version in reports_by_version:
-            reports_by_version[api_version].sort(
-                key=lambda r: (r.organization.lower(), r.project.lower())
-            )
-
-        versions = sorted(reports_by_version.keys(), reverse=True) # versions in descending order
-        sections = [generate_version_section(v, reports_by_version[v]) for v in versions]
-        output_file.write_text("\n".join(sections))
-        print(f"Generated {output_file}")
+    output_file = project_dir / "conformance-matrix.md"
+    sections = matrix.generate_reports()
+    output_file.write_text(sections)
+    print(f"Generated {output_file}")
 
 
 if __name__ == "__main__":

--- a/hack/generate-conformance-matrix.py
+++ b/hack/generate-conformance-matrix.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generate per-version MCS API conformance comparison page from submitted YAML reports.
+"""Generate per-version MCS API conformance comparison pages from submitted YAML reports.
 
 Scans the mcs-implementations reports/ subdirectory for reports as YAML files and
-generates a comparison Markdown page in the mcs-implementations directory.
+generates comparison Markdown pages under its generated/ directory (which is gitignored).
 
 Expected layout:
 site-src/
@@ -26,7 +26,11 @@ site-src/
                 v0.5.0/submariner/v0.23.0.yaml    (submitted)
                 v0.5.0/gke/2026-01-01.yaml        (submitted)
                 v0.5.0/gke/2026-07-01.yaml        (submitted)
-            conformance-matrix.md                 (generated)
+            generated/                            (generated, gitignored)
+                conformance-matrix.md
+                v0.5.0/submariner/v0.23.0.md
+                v0.5.0/gke/2026-01-01.md
+                v0.5.0/gke/2026-07-01.md
 """
 
 from __future__ import annotations
@@ -38,7 +42,8 @@ from typing import Any
 
 import yaml
 
-REPO_URL = "https://github.com/kubernetes-sigs/sig-multicluster-site"
+import mcs_report
+
 MCS_IMPLEMENTATIONS_DIR = "site-src/implementations/mcs-implementations"
 
 
@@ -46,11 +51,12 @@ MCS_IMPLEMENTATIONS_DIR = "site-src/implementations/mcs-implementations"
 class SubmittedReport:
     """A single submitted conformance report by an implementer"""
     report_yaml: dict[str, Any]
-    report_file: pathlib.Path
+    report_name: str
+    generated_report_dir: pathlib.Path
 
-    def row(self) -> str:
+    def row(self, project_dir: pathlib.Path) -> str:
         """Generates each table row in the comparisons page"""
-        report_link = f"[{self.report_file.name}]({REPO_URL}/blob/main/{self.report_file.as_posix()})"
+        report_link = self.report_path().relative_to(project_dir).as_posix()
         cols: list[str] = []
         required_passed, required_total = self.required_counts()
         cols.append(self.organization())
@@ -58,8 +64,30 @@ class SubmittedReport:
         cols.append(self.version())
         cols.append(self.tests_col(required_passed, required_total)) # Required Tests
         cols.append(self.tests_col(self.passed(), self.total())) # Total Tests
-        cols.append(report_link) # Report
+        cols.append(f"[{self.report_name}]({report_link})") # Report
         return "| " + " | ".join(cols) + " |"
+
+    def report_path(self) -> pathlib.Path:
+        return self.generated_report_dir / f"{self.report_name}.md"
+
+    def generate_report(self, mcs_api_ver: str) -> None:
+        """Generates the MCS conformance report for an implementation under generated/"""
+        test_sections: list[mcs_report.TestSection] = []
+        for group in self.report_yaml["groups"]: # Required / Optional section 
+            test_rows = [mcs_report.TestRow(test_data) for test_data in group["tests"]]
+            test_section = mcs_report.TestSection(name=group["name"], tests=test_rows)
+            test_sections.append(test_section)
+
+        conformance_report = mcs_report.ConformanceReport( # generates md report
+            mcs_api_ver=mcs_api_ver,
+            organization=self.organization(),
+            project=self.project(),
+            project_url=self.url(),
+            impl_ver=self.version(),
+            sections=test_sections,
+        )
+        self.generated_report_dir.mkdir(parents=True, exist_ok=True)
+        conformance_report.generate(self.report_path())
 
     def tests_col(self, passed: int, total: int) -> str:
         green_tick = " :white_check_mark:" if passed == total else ""
@@ -107,21 +135,23 @@ class SubmittedReport:
 @dataclass
 class ConformanceMatrix:
     """Collects submitted reports by MCS API version and renders the comparison matrix."""
+    project_dir: pathlib.Path  # mcs-implementations directory
     reports_by_version: dict[str, list[SubmittedReport]] = field(default_factory=dict)
 
     @staticmethod
-    def header() -> list[str]:
-        return [
-            "| Organization | Project | Version | Required Tests | Total Tests | Report |",
-            "|---|---|---|---|---|---|",
-        ]
+    def header() -> str:
+        return (
+            "| Organization | Project | Version | Required Tests | Total Tests | Report |\n"
+            "|---|---|---|---|---|---|"
+        )
 
     def matrix(self, mcs_api_ver: str, submitted_reports: list[SubmittedReport]) -> str:
         """Generates comparisons tables for a single MCS version"""
         lines: list[str] = [f"## {mcs_api_ver}"]
-        lines.extend(self.header())
+        lines.append(self.header())
         for submitted_report in submitted_reports:
-            lines.append(submitted_report.row())
+            submitted_report.generate_report(mcs_api_ver)
+            lines.append(submitted_report.row(self.project_dir))
         return "\n".join(lines)
 
     def add_report(self, mcs_api_ver: str, submitted_report: SubmittedReport) -> None:
@@ -145,19 +175,25 @@ class ConformanceMatrix:
 def main() -> None:
     project_dir = pathlib.Path(MCS_IMPLEMENTATIONS_DIR)
     reports_dir = project_dir / "reports"
+    output_dir = project_dir / "generated" # artifacts are generated in this directory
+    output_dir.mkdir(parents=True, exist_ok=True) # create generated/ directory
 
-    matrix = ConformanceMatrix()
+    matrix = ConformanceMatrix(project_dir=project_dir) # generates conformance-matrix.md
     for report_file in sorted(reports_dir.glob("*/*/*.yaml")):
         with open(report_file) as f:
             report_yaml: dict[str, Any] = yaml.safe_load(f)
         mcs_api_ver = report_file.parent.parent.name
+        # Mirror per-version reports layout (e.g. v0.5.0/gke/) under the generated directory
         submitted_report = SubmittedReport(
             report_yaml=report_yaml,
-            report_file=report_file,
+            report_name=report_file.stem,
+            # e.g. report_file = `<path-prefix>/reports/v0.5.0/gke/2026-07-01.yaml`
+            # report_file.parent.relative_to(reports_dir) = `reports/v0.5.0/gke`
+            generated_report_dir=output_dir / report_file.parent.relative_to(reports_dir),
         )
         matrix.add_report(mcs_api_ver, submitted_report)
 
-    output_file = project_dir / "conformance-matrix.md"
+    output_file = output_dir / "conformance-matrix.md"
     sections = matrix.generate_reports()
     output_file.write_text(sections)
     print(f"Generated {output_file}")

--- a/hack/generate-conformance-matrix.py
+++ b/hack/generate-conformance-matrix.py
@@ -55,15 +55,14 @@ class SubmittedReport:
     generated_report_dir: pathlib.Path
 
     def row(self, project_dir: pathlib.Path) -> str:
-        """Generates each table row in the comparisons page"""
+        """Render each table row in the comparisons page"""
         report_link = self.report_path().relative_to(project_dir).as_posix()
         cols: list[str] = []
-        required_passed, required_total = self.required_counts()
         cols.append(self.organization())
         cols.append(self.project_col())
         cols.append(self.version())
-        cols.append(self.tests_col(required_passed, required_total)) # Required Tests
-        cols.append(self.tests_col(self.passed(), self.total())) # Total Tests
+        cols.append(self.required_tests_col()) # Required Tests
+        cols.append(self.total_tests_col()) # Total Tests
         cols.append(f"[{self.report_name}]({report_link})") # Report
         return "| " + " | ".join(cols) + " |"
 
@@ -72,11 +71,9 @@ class SubmittedReport:
 
     def generate_report(self, mcs_api_ver: str) -> None:
         """Generates the MCS conformance report for an implementation under generated/"""
-        test_sections: list[mcs_report.TestSection] = []
-        for group in self.report_yaml["groups"]: # Required / Optional section 
-            test_rows = [mcs_report.TestRow(test_data) for test_data in group["tests"]]
-            test_section = mcs_report.TestSection(name=group["name"], tests=test_rows)
-            test_sections.append(test_section)
+        test_sections: list[mcs_report.TestSection] = list(  # Required / Optional section
+            map(mcs_report.TestSection.from_yaml_group, self.report_yaml["groups"])
+        )
 
         conformance_report = mcs_report.ConformanceReport( # generates md report
             mcs_api_ver=mcs_api_ver,
@@ -89,29 +86,20 @@ class SubmittedReport:
         self.generated_report_dir.mkdir(parents=True, exist_ok=True)
         conformance_report.generate(self.report_path())
 
-    def tests_col(self, passed: int, total: int) -> str:
-        green_tick = " :white_check_mark:" if passed == total else ""
-        return f"{passed}/{total}{green_tick}"
+    def total_tests_col(self) -> str:
+        green_tick = " :white_check_mark:" if self.passed() == self.total() else ""
+        return f"{self.passed()}/{self.total()}{green_tick}"
 
     def project_col(self) -> str:
         if self.url():
             return f"[{self.project()}]({self.url()})"
         return self.project()
 
-    def required_counts(self) -> tuple[int, int]:
-        required_passed = 0
-        required_total = 0
-
+    def required_tests_col(self) -> str:
         for group in self.report_yaml["groups"]:
-            if group["name"] != "Required":
-                continue  # skip non-required groups
-
-            for test in group["tests"]:
-                required_total += 1
-                if test["passed"]:
-                    required_passed += 1
-
-        return required_passed, required_total
+            if group["name"] == "Required":
+                return mcs_report.TestSection.from_yaml_group(group).passed_summary()
+        raise ValueError("Required tests not found")
 
     def project(self) -> str:
         return self.report_yaml["implementation"].get("project", "")
@@ -146,19 +134,18 @@ class ConformanceMatrix:
         )
 
     def matrix(self, mcs_api_ver: str, submitted_reports: list[SubmittedReport]) -> str:
-        """Generates comparisons tables for a single MCS version"""
+        """Render comparisons table for a single MCS version"""
         lines: list[str] = [f"## {mcs_api_ver}"]
         lines.append(self.header())
         for submitted_report in submitted_reports:
-            submitted_report.generate_report(mcs_api_ver)
             lines.append(submitted_report.row(self.project_dir))
         return "\n".join(lines)
 
     def add_report(self, mcs_api_ver: str, submitted_report: SubmittedReport) -> None:
         self.reports_by_version.setdefault(mcs_api_ver, []).append(submitted_report)
 
-    def generate_reports(self) -> str:
-        """Generates all the tables in mcs-implementations/comparisons/"""
+    def comparison_tables(self) -> str:
+        """Render all per-version comparison tables (for /comparisons page) as markdown."""
         self.sort()
         tables: list[str] = []
         # Iterate in descending order of MCS version
@@ -191,10 +178,11 @@ def main() -> None:
             # report_file.parent.relative_to(reports_dir) = `reports/v0.5.0/gke`
             generated_report_dir=output_dir / report_file.parent.relative_to(reports_dir),
         )
+        submitted_report.generate_report(mcs_api_ver)
         matrix.add_report(mcs_api_ver, submitted_report)
 
     output_file = output_dir / "conformance-matrix.md"
-    sections = matrix.generate_reports()
+    sections = matrix.comparison_tables()
     output_file.write_text(sections)
     print(f"Generated {output_file}")
 

--- a/hack/mcs_report.py
+++ b/hack/mcs_report.py
@@ -1,0 +1,123 @@
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render a single MCS API conformance report as a Markdown page.
+
+Provides the data structures that turn one submitted conformance YAML report
+into a detailed Markdown page (similar to the suite's report.html). Used by
+generate-conformance-matrix.py, which links to each generated page from the
+comparison matrix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import pathlib
+from typing import Any
+
+@dataclass
+class TestRow:
+    """A single test row in the HTML conformance report."""
+    result: dict[str, Any] # Each test result `groups[*].tests[i]`
+
+    def row(self) -> str:
+        cols: list[str] = []
+        cols.append(self.conformant_col())
+        cols.append(self.labels_col())
+        cols.append(self.description_col())
+        return "| " + " | ".join(cols) + " |"
+
+    def conformant_col(self) -> str:
+        if self.skipped():
+            return ':octicons-skip-16: Skipped'
+        if self.failed():
+            return ":warning: Unknown"
+        if self.conformant():
+            return ":white_check_mark: Yes"
+        return ":x: No"
+
+    def labels_col(self) -> str:
+        return " ".join(f"`{label}`" for label in self.labels())
+
+    def description_col(self) -> str:
+        if not self.description_url():
+            return self.description()
+        return f"[{self.description()}]({self.description_url()})"
+
+    def failed(self) -> bool:
+        return self.result["failed"]
+
+    def skipped(self) -> bool:
+        return self.result["skipped"]
+
+    def conformant(self) -> bool:
+        return self.result["conformant"]
+
+    def description(self) -> str:
+        return self.result["desc"]
+
+    def description_url(self) -> str | None:
+        return self.result.get("ref")
+
+    def labels(self) -> list[str]:
+        return self.result.get("labels", [])
+
+
+@dataclass
+class TestSection:
+    """A named section (Required / Optional) of the HTML report."""
+    name: str
+    tests: list[TestRow] = field(default_factory=list)
+
+    @staticmethod
+    def header() -> str:
+        return (
+            "| Conformant | Labels | Description |\n"
+            "|---|---|---|"
+        )
+    
+    def section(self) -> str:
+        lines: list[str] = []
+        lines.append(f"## {self.name} Tests")
+        lines.append(self.header())
+        for test in self.tests:
+            lines.append(test.row())
+        return "\n".join(lines)
+
+
+@dataclass
+class ConformanceReport:
+    """Generates detailed conformance report similar to report.html"""
+    mcs_api_ver: str
+    organization: str
+    project: str
+    project_url: str
+    impl_ver: str
+    sections: list[TestSection] = field(default_factory=list)
+
+    def report(self) -> str:
+        lines: list[str] = []
+        lines.append("# MCS API Conformance Report")
+        lines.append(f"* MCS API Version: {self.mcs_api_ver}")
+        lines.append(f"* Organization: {self.organization}")
+        lines.append(f"* Project: [{self.project}]({self.project_url})")
+        lines.append(f"* Implementation Version: {self.impl_ver}")
+        for section in self.sections:
+            lines.append(section.section())
+        return "\n\n".join(lines)
+
+    def generate(self, path: pathlib.Path) -> None:
+        with open(path, "w") as f:
+            f.write(self.report())

--- a/hack/mcs_report.py
+++ b/hack/mcs_report.py
@@ -65,6 +65,9 @@ class TestRow:
     def conformant(self) -> bool:
         return self.result["conformant"]
 
+    def passed(self) -> bool:
+        return self.result["passed"]
+
     def description(self) -> str:
         return self.result["desc"]
 
@@ -82,6 +85,11 @@ class TestSection:
     tests: list[TestRow] = field(default_factory=list)
 
     @staticmethod
+    def from_yaml_group(group_yaml: dict) -> "TestSection": # groups[i] of yaml report
+        tests = [TestRow(testrow) for testrow in group_yaml["tests"]]
+        return TestSection(group_yaml["name"], tests)
+    
+    @staticmethod
     def header() -> str:
         return (
             "| Conformant | Labels | Description |\n"
@@ -91,10 +99,26 @@ class TestSection:
     def section(self) -> str:
         lines: list[str] = []
         lines.append(f"## {self.name} Tests")
+        lines.append(f"Passed: {self.passed_summary()}\n")
         lines.append(self.header())
         for test in self.tests:
             lines.append(test.row())
         return "\n".join(lines)
+
+    def passed_counts(self) -> tuple[int, int]:
+        passed = sum(1 for test in self.tests if test.passed())
+        total = len(self.tests)
+        return passed, total
+
+    def passed_summary(self) -> str:
+        passed, total = self.passed_counts()
+        icon = ""
+        if passed == total:
+            icon = " :white_check_mark:"
+        elif self.name == "Required":
+            assert passed > 0, "Required tests should have at least one passed test"
+            icon = " :warning:"
+        return f"{passed}/{total}{icon}"
 
 
 @dataclass
@@ -109,7 +133,7 @@ class ConformanceReport:
 
     def report(self) -> str:
         lines: list[str] = []
-        lines.append("# MCS API Conformance Report")
+        lines.append(f"# {self.project} MCS API Conformance Report")
         lines.append(f"* MCS API Version: {self.mcs_api_ver}")
         lines.append(f"* Organization: {self.organization}")
         lines.append(f"* Project: [{self.project}]({self.project_url})")

--- a/hack/mcs_report.py
+++ b/hack/mcs_report.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+import html
 import pathlib
 from typing import Any
 
@@ -69,7 +70,7 @@ class TestRow:
         return self.result["passed"]
 
     def description(self) -> str:
-        return self.result["desc"]
+        return html.escape(self.result["desc"])
 
     def description_url(self) -> str | None:
         return self.result.get("ref")

--- a/site-src/implementations/mcs-implementations/comparisons.md
+++ b/site-src/implementations/mcs-implementations/comparisons.md
@@ -1,4 +1,4 @@
 # Conformance Comparisons
 The latest MCS API version is <a href="https://github.com/kubernetes-sigs/mcs-api/releases/latest"><img src="https://img.shields.io/github/v/release/kubernetes-sigs/mcs-api?label=&color=green" style="vertical-align: middle;" alt="MCS API Latest Release"></a>. Below are the conformance test results submitted by known implementations, grouped by conformance suite version.
 
---8<-- "site-src/implementations/mcs-implementations/conformance-matrix.md"
+--8<-- "site-src/implementations/mcs-implementations/generated/conformance-matrix.md"


### PR DESCRIPTION
Fixes #60

### Summary
1. File `mcs_report.py` generates a detailed MCS conformance report similar to report.html file generated by the MCS conformance tool
2. Refactor conformance matrix generator code. The code was little hard to read and adding the link to the detailed conformance report would have made the code more messy.
3. `generate-conformance-matrix.py` now looks at the MCS implementation directory instead of "site-src/implementations" which is one level above "mcs-implementations". I previously thought that this code could be utilized by other multicluster project but I don't think there is a conformance tool for other projects, hence made the code specific to MCS which made some of the code logic simpler
4. All the reports are generated in gitignored "site-src/implementations/*/generated/" directory 