### PR TITLE
Bump Netlify Python version to 3.14

### DIFF
--- a/hack/generate-conformance-matrix.py
+++ b/hack/generate-conformance-matrix.py
@@ -33,8 +33,6 @@ site-src/
                 v0.5.0/gke/2026-07-01.md
 """
 
-from __future__ import annotations
-
 import pathlib
 from dataclasses import dataclass
 from dataclasses import field

--- a/hack/mcs_report.py
+++ b/hack/mcs_report.py
@@ -20,8 +20,6 @@ generate-conformance-matrix.py, which links to each generated page from the
 comparison matrix.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from dataclasses import field
 import html

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
 [build]
     command = "make docs"
     publish = "site"
-    environment = { PYTHON_VERSION = "3.8" }
+    environment = { PYTHON_VERSION = "3.14" }


### PR DESCRIPTION
Fixes: #56 

Update PYTHON_VERSION from 3.8 to 3.14 and drop the now-unnecessary `from __future__ import annotations` imports from the hack/ scripts.