### PR TITLE
reports: update Cilium report for 1.20.0

### DIFF
--- a/site-src/implementations/mcs-implementations/index.md
+++ b/site-src/implementations/mcs-implementations/index.md
@@ -14,7 +14,7 @@ See the [Comparisons](comparisons.md) page for conformance test results submitte
 - [Submariner][submariner]: 0.13.3
 - [MCS controller for AWS Cloudmap][aws-mcs]: Alpha
 - [Antrea Multi-cluster][antrea-mcs]: Alpha
-- [Cilium Cluster Mesh][cilium-clustermesh]: Beta (from Cilium v1.17)
+- [Cilium Cluster Mesh][cilium-clustermesh]: Stable
 
 ## Implementations
 
@@ -67,11 +67,18 @@ Please follow this [guide][antrea-mcs-user-guide] for the first steps to set up 
 
 ### Cilium Cluster Mesh
 
+[![Conformance](https://img.shields.io/badge/MCS%20API%20Conformance%20v0.5.2-Cilium-green)](generated/v0.5.2/cilium/1.20.0.md)
+
 [Cilium][cilium] is an open source, cloud native solution for providing, securing, and observing network connectivity between workloads, fueled by the Kernel technology eBPF.
 
-[Cilium Cluster Mesh][cilium-clustermesh] allows you to connect the networks of multiple clusters in such as way that pods in each cluster can discover and access services in all other clusters of the mesh, provided all the clusters run Cilium as their CNI. This allows effectively joining multiple clusters into a large unified network, regardless of the Kubernetes distribution or location each of them is running.
+[Cilium Cluster Mesh][cilium-clustermesh] extends Cilium networking across multiple Kubernetes clusters and provides:
 
-Starting with Cilium version 1.17, Cilium Cluster Mesh also supports MCS API; see the corresponding [guide][cilium-mcs] for more information!
+- Pod-to-pod connectivity between clusters within a flat IP address space
+- Cluster-aware network policy enforcement
+- Cross-cluster service discovery and load-balancing
+- Service affinity controls to prefer local or remote backends
+
+Cilium Cluster Mesh is a conformant MCS API implementation; see the corresponding [guide][cilium-mcs] for more information!
 
 [cilium]: https://cilium.io/
 [cilium-clustermesh]: https://cilium.io/use-cases/cluster-mesh/

--- a/site-src/implementations/mcs-implementations/reports/README.md
+++ b/site-src/implementations/mcs-implementations/reports/README.md
@@ -41,7 +41,20 @@ reports/
    - `<impl-name>` is a lowercase identifier for your implementation (e.g., `submariner`, `gke`, `cilium`)
    - Optionally rename the file to your implementation version (e.g., `v0.23.0.yaml`, `2026-01-01.yaml`) — `report.yaml` is also fine
 
-3. **Open a pull request** against the
+3. **Document how to reproduce the report** in a Markdown file, either at
+   `reports/<impl-name>.md` or, if the steps are specific to one conformance version,
+   at `reports/<conformance-version>/<impl-name>/README.md`.
+
+4. **Update your entry in the [implementations list](../index.md)**: refresh your support
+   level and add or update your conformance badge so it points at your latest report:
+
+   ```markdown
+   [![Conformance](https://img.shields.io/badge/MCS%20API%20Conformance%20<conformance-version>-<Project>-<green/orange>)](generated/<conformance-version>/<impl-name>/<impl-version>.md)
+   ```
+
+   Use `green` if all required tests pass and `orange` otherwise.
+
+5. **Open a pull request** against the
    [sig-multicluster-site](https://github.com/kubernetes-sigs/sig-multicluster-site) repository.
 
 ## Requirements

--- a/site-src/implementations/mcs-implementations/reports/v0.5.2/cilium/1.20.0.yaml
+++ b/site-src/implementations/mcs-implementations/reports/v0.5.2/cilium/1.20.0.yaml
@@ -9,6 +9,14 @@ groups:
           skipped: false
           conformant: true
           message: ""
+        - desc: A ServiceImport should publish whether EndpointSlice objects are present
+          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#using-endpointslice-objects-to-track-endpoints
+          labels: []
+          passed: true
+          failed: false
+          skipped: false
+          conformant: true
+          message: ""
         - desc: A service exported on two clusters with conflicting headlessness should apply the conflict resolution policy and report a Conflict condition on the ServiceExport
           ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#headlessness
           labels: []
@@ -258,10 +266,10 @@ groups:
           message: ""
 suitefailure: ""
 dnsdomain: clusterset.local
-passed: 26
-total: 27
+passed: 27
+total: 28
 implementation:
     organization: Cilium
     project: Cilium
-    version: 1.20.0-dev
+    version: 1.20.0
     url: https://cilium.io/


### PR DESCRIPTION
The 1.20.0 report is based on the result of this CI: https://github.com/cilium/cilium/actions/runs/30466666325.

Cilium now support MCS-API at a stable level, reflect that in the implementation list and update Cilium description.

Also update the report documentation for implementations to add a badge and to include documentation on replicating their reports.